### PR TITLE
Catch Apple Pay exception

### DIFF
--- a/src/dropin-model.js
+++ b/src/dropin-model.js
@@ -215,7 +215,11 @@ function isPaymentOptionEnabled(paymentOption, options) {
     return gatewayConfiguration.paypalEnabled && Boolean(options.merchantConfiguration.paypalCredit);
   } else if (paymentOption === 'applePay') {
     applePayEnabled = gatewayConfiguration.applePayWeb && Boolean(options.merchantConfiguration.applePay);
-    applePayBrowserSupported = global.ApplePaySession && global.ApplePaySession.canMakePayments();
+    try {
+      applePayBrowserSupported = global.ApplePaySession && global.ApplePaySession.canMakePayments();
+    } catch () {
+      applePayBrowserSupported = false;
+    }
 
     if (!applePayEnabled || !applePayBrowserSupported) { return false; }
     return true;


### PR DESCRIPTION
This catches an error that might happen when checking Apple Pay availablity. For example in development the `ApplePaySession` API might throw (InvalidAccessError (DOM Exception 15): Trying to call an ApplePaySession API from an insecure document) because the dropin is embedded in a non-https webpage (localhost).

### Summary

### Checklist

- [ ] Added a changelog entry
